### PR TITLE
Use map for variant aliases instead of list

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,22 +37,26 @@ Add settings for the experiments:
 
 - id: Experiment ID required to identify variants for the experiment in templates
 - alias: Alias for the experiment ID, optional useful for clarity in templates when accessing experiment variants by key
-- variant_aliases: Aliases for each variant, each index represents a Google Experiment variant
+- variant_aliases: Aliases for each variant, each index represents a Optmize Experiment variant
 
 ```py
 # google-optimize
 GOOGLE_OPTIMIZE_EXPERIMENTS = [
-    {"id": "abc", "alias": "subscribe_box", "variant_aliases": ["old_sub_box", "new_sub_box"]}
+    {
+        "id": "utSuKi3PRbmxeG08en8VNw",
+        "alias": "redesign",
+        "variant_aliases": {0: "old_design", 1: "new_design"},
+    }
 ]
 ```
 
 Now you can access the experiment in templates:
 
 ```django
-{% if google_optimize.subscribe_box == "new_subscribe" %}
-{% include "xyz/new_sub_box.html" %}
+{% if google_optimize.redesign == "new_design" %}
+{% include "jobs/jobposting_list_new.html" %}
 {% else %}
-{% include "xyz/old_sub_box.html" %}
+{% include "jobs/jobposting_list_old.html" %}
 {% endif %}
 ```
 
@@ -60,7 +64,7 @@ Or use it inline:
 
 ```django
 <nav class="navbar navbar-expand-lg navbar-dark
-{% if google_optimize.redesign == "new_design" %}navbar-redesign {% endif %}">
+{% if google_optimize.redesign == "new_design" %} navbar-redesign{% endif %}">
 ```
 
 Full documentation [can be found here.](https://django-google-optimize.readthedocs.io/en/latest/)

--- a/google_optimize/utils.py
+++ b/google_optimize/utils.py
@@ -7,7 +7,6 @@ def get_experiments_variants(request, experiments):
     try:
         experiment_variants = _parse_experiments(request)
     except Exception:  # pylint: disable=broad-except
-        print("here")
         logger.error("Failed to parse _gaexp %s", request.COOKIES.get("_gaexp"))
         return None
 
@@ -37,17 +36,9 @@ def get_experiments_variants(request, experiments):
 
         variant = experiment_variants[experiment_id]
 
-        print(variant_aliases)
-        print("hey1")
         if variant_aliases:
-            print("here2")
-            print(variant_aliases)
-            if int(variant) >= len(variant_aliases):
-                logger.warning(
-                    "variant %s does not have an alias in %s", variant, variant_aliases
-                )
-                return None
-            variant = variant_aliases[int(variant)]
+            if variant in variant_aliases:
+                variant = variant_aliases[variant]
 
         if experiment_alias:
             active_experiments[experiment_alias] = variant
@@ -70,6 +61,6 @@ def _parse_experiments(request):
     for experiment_str in experiments:
         experiment_parts = experiment_str.split(".")
         experiment_id = experiment_parts[0]
-        variation_id = experiment_parts[2]
+        variation_id = int(experiment_parts[2])
         experiment_variations[experiment_id] = variation_id
     return experiment_variations

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -25,6 +25,6 @@ GOOGLE_OPTIMIZE_EXPERIMENTS = [
     {
         "id": "utSuKi3PRbmxeG08en8VNw",
         "alias": "redesign",
-        "variant_aliases": ["old_design", "new_design"],
+        "variant_aliases": {0: "old_design", 1: "new_design"},
     }
 ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ def test_parses_single_experiment_cookie():
     request = HttpRequest()
     request.COOKIES["_gaexp"] = "GAX1.2.utSuKi3PRbmxeG08en8VNw.18147.1"
     experiments = _parse_experiments(request)
-    assert experiments == dict(utSuKi3PRbmxeG08en8VNw="1")
+    assert experiments == dict(utSuKi3PRbmxeG08en8VNw=1)
 
 
 def test_parses_multiple_experiment_cookies():
@@ -18,7 +18,7 @@ def test_parses_multiple_experiment_cookies():
         "_gaexp"
     ] = "GAX1.2.3x8_BbSCREyqtWm1H1OUrQ.18166.1!7IXTpXmLRzKwfU-Eilh_0Q.18166.0"
     experiments = _parse_experiments(request)
-    assert experiments == {"7IXTpXmLRzKwfU-Eilh_0Q": "0", "3x8_BbSCREyqtWm1H1OUrQ": "1"}
+    assert experiments == {"7IXTpXmLRzKwfU-Eilh_0Q": 0, "3x8_BbSCREyqtWm1H1OUrQ": 1}
 
 
 def test_parses_without_cookie():
@@ -62,21 +62,6 @@ def test_logs_experiment_id_not_in_cookies(logger):
     )
 
 
-@mock.patch("logging.Logger.warning")
-def test_logs_variant_missing_alias(logger):
-    request = HttpRequest()
-    variant = "1"
-    experiment_id = "3x8_BbSCREyqtWm1H1OUrQ"
-    request.COOKIES["_gaexp"] = "GAX1.2." + experiment_id + ".18166." + variant
-    aliases = ["abc"]
-    get_experiments_variants(
-        request, [{"id": experiment_id, "variant_aliases": aliases}]
-    )
-    logger.assert_called_with(
-        "variant %s does not have an alias in %s", variant, aliases
-    )
-
-
 def test_parses_single_experiment():
     request = HttpRequest()
     request.COOKIES["_gaexp"] = "GAX1.2.utSuKi3PRbmxeG08en8VNw.18147.1"
@@ -84,7 +69,7 @@ def test_parses_single_experiment():
         {
             "id": "utSuKi3PRbmxeG08en8VNw",
             "alias": "redesign",
-            "variant_aliases": ["old_design", "new_design"],
+            "variant_aliases": {0: "old_design", 1: "new_design"},
         }
     ]
     values = get_experiments_variants(request, experiments)
@@ -100,12 +85,12 @@ def test_parses_multiple_experiments():
         {
             "id": "3x8_BbSCREyqtWm1H1OUrQ",
             "alias": "redesign_page",
-            "variant_aliases": ["old_design", "new_design"],
+            "variant_aliases": {0: "old_design", 1: "new_design"},
         },
         {
             "id": "7IXTpXmLRzKwfU-Eilh_0Q",
             "alias": "resign_header",
-            "variant_aliases": ["old_header", "new_header"],
+            "variant_aliases": {0: "old_header", 1: "new_header"},
         },
     ]
     values = get_experiments_variants(request, experiments)
@@ -118,7 +103,7 @@ def test_parses_experiments_without_variant_aliases():
     request.COOKIES["_gaexp"] = "GAX1.2.utSuKi3PRbmxeG08en8VNw.18147.1"
     experiments = [{"id": "utSuKi3PRbmxeG08en8VNw", "alias": "redesign"}]
     values = get_experiments_variants(request, experiments)
-    assert values == {"redesign": "1"}
+    assert values == {"redesign": 1}
 
 
 def test_parses_experiments_without_experiment_alias():
@@ -126,4 +111,4 @@ def test_parses_experiments_without_experiment_alias():
     request.COOKIES["_gaexp"] = "GAX1.2.utSuKi3PRbmxeG08en8VNw.18147.1"
     experiments = [{"id": "utSuKi3PRbmxeG08en8VNw"}]
     values = get_experiments_variants(request, experiments)
-    assert values == {"utSuKi3PRbmxeG08en8VNw": "1"}
+    assert values == {"utSuKi3PRbmxeG08en8VNw": 1}


### PR DESCRIPTION
Map names closer to how google has the gaexp cookie.