### PR TITLE
Fix: Failing on multiple active experiments

### DIFF
--- a/django_google_optimize/utils.py
+++ b/django_google_optimize/utils.py
@@ -35,7 +35,7 @@ def get_experiments_variants(request):
                 experiment_id,
                 request.COOKIES.get("_gaexp"),
             )
-            return None
+            continue
 
         variant_name = cookie_data[experiment_id]
 


### PR DESCRIPTION
Fix: Prevent get_experiment_variants from failing if one active experiment is not present in the _gaexp cookies, instead continue looking for other active experiments.